### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pretto/eslint-config-pretto",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "repository": "git@github.com:finspot/eslint-config-pretto.git",
   "files": [
     "index.js"
@@ -11,17 +11,17 @@
     "eslint"
   ],
   "dependencies": {
-    "@rushstack/eslint-patch": "^1.3.3",
-    "@typescript-eslint/eslint-plugin": "^6.3.0",
-    "@typescript-eslint/parser": "^6.3.0",
+    "@rushstack/eslint-patch": "^1.12.3",
+    "@typescript-eslint/eslint-plugin": "^8.37.0",
+    "@typescript-eslint/parser": "^8.37.0",
     "eslint-config-typescript": "^3.0.0",
     "eslint-plugin-jest": "^27.2.3",
     "eslint-plugin-react": "^7.33.1"
   },
   "devDependencies": {
-    "eslint": "^8.46.0",
+    "eslint": "^9.31.0",
     "jest": "^29.6.2",
-    "typescript": "^4.9.5"
+    "typescript": "^5.8.3"
   },
   "peerDependencies": {
     "jest": ">=29",


### PR DESCRIPTION
We upgrade Typescript version to the last version (v5.8.3 currently) in ours stack but eslint v8 is not not ready for that so we have to update this library.

## Overview of changes

This pull request updates the dependencies in the `package.json` file to their latest versions. Here are the specific changes:

- Bump version from `2.1.0` to `2.2.0`
- Update `@rushstack/eslint-patch` from `^1.3.3` to `^1.12.3`
- Update `@typescript-eslint/eslint-plugin` from `^6.3.0` to `^8.37.0`
- Update `@typescript-eslint/parser` from `^6.3.0` to `^8.37.0`
- Update `eslint` (devDependency) from `^8.46.0` to `^9.31.0`
- Update `typescript` (devDependency) from `^4.9.5` to `^5.8.3`

Only one file (`package.json`) was modified, with a total of 6 additions and 6 deletions.

## What might be broken

There is a small risk that the new versions of the dependencies could introduce breaking changes or incompatibilities with existing configurations or plugins. This has not been exhaustively tested across all possible project setups, so issues may arise in edge cases.

## What has been tested

Basic validation was performed to ensure that the project installs and lints correctly with the updated dependencies. No advanced or project-specific tests were conducted.